### PR TITLE
イベント詳細ページの前後ナビゲーションを左右入れ替え

### DIFF
--- a/src/templates/event_detail.html
+++ b/src/templates/event_detail.html
@@ -191,14 +191,14 @@
     </section>
 
     <nav class="event-nav">
-      {% if prev_event_num %}
-      <a href="{{ base_path }}/events/{{ '%03d' | format(prev_event_num) }}" class="btn btn-outline event-nav-btn">← #{{ prev_event_num }}</a>
+      {% if next_event_num %}
+      <a href="{{ base_path }}/events/{{ '%03d' | format(next_event_num) }}" class="btn btn-outline event-nav-btn">← #{{ next_event_num }}</a>
       {% else %}
       <span class="event-nav-btn"></span>
       {% endif %}
       <a href="{{ base_path }}/" class="btn btn-outline event-nav-btn">イベント一覧</a>
-      {% if next_event_num %}
-      <a href="{{ base_path }}/events/{{ '%03d' | format(next_event_num) }}" class="btn btn-outline event-nav-btn">#{{ next_event_num }} →</a>
+      {% if prev_event_num %}
+      <a href="{{ base_path }}/events/{{ '%03d' | format(prev_event_num) }}" class="btn btn-outline event-nav-btn">#{{ prev_event_num }} →</a>
       {% else %}
       <span class="event-nav-btn"></span>
       {% endif %}


### PR DESCRIPTION
## Summary
- イベント詳細ページ下部の前後ナビゲーションを左右入れ替え（左=新しい、右=古い）
- トップページの年ナビゲーションと向きを揃え、ユーザーの混乱を回避

## Test plan
- [x] ローカルビルドで `events/002/` から ← で #3、→ で #1 に遷移できることを確認
- [x] 最新回（末尾なし）と最古回（先頭なし）で空白表示が崩れないことを確認