### PR TITLE
イベント詳細・登壇者詳細ページにXシェア導線を追加

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1270,6 +1270,59 @@ img {
   margin-bottom: 40px;
 }
 
+/* --- Share Button --- */
+.section-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.section-header-row h2 {
+  margin-bottom: 0;
+}
+
+.share-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-white);
+  color: var(--color-text-light);
+  border: 1px solid var(--color-border);
+  font-size: 0.78rem;
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  text-decoration: none;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.share-button:hover {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-color: var(--color-text-light);
+}
+
+.share-button .icon {
+  width: 12px;
+  height: 12px;
+}
+
+/* --- Hashtag Share (event detail) --- */
+.hashtag-share {
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.hashtag-share:hover {
+  background: var(--color-primary-bg);
+  color: var(--color-primary-dark);
+}
+
 /* --- 404 Page --- */
 .not-found {
   text-align: center;

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -14,5 +14,5 @@ OUTPUT_DIR = PROJECT_ROOT / "output"
 SITE_NAME = "My Community"
 SITE_TITLE = "My Community Portal"
 SITE_DESCRIPTION = "エンジニア達のLTイベント - 発表資料アーカイブ"
-SITE_URL = ""  # デプロイ後に設定（例: "https://username.github.io/engineer-community-portal"）
+SITE_URL = "https://unsolublesugar.github.io/engineer-community-portal"  # デプロイ後に設定（例: "https://username.github.io/engineer-community-portal"）
 SITE_OG_IMAGE = ""  # OG画像のURL（例: "https://username.github.io/engineer-community-portal/images/og-image.png"）

--- a/src/templates/_macros.html
+++ b/src/templates/_macros.html
@@ -1,0 +1,17 @@
+{#
+  共通マクロ定義
+#}
+
+{#
+  Xシェアボタン
+  Args:
+    text: シェアテキスト（ページタイトル等）
+    path: サイトURLからの相対パス（例: "/events/075"、トップは ""）
+#}
+{% macro share_button(text, path='') -%}
+<a href="https://twitter.com/intent/tweet?text={{ text | urlencode }}&url={{ (site_url + path) | urlencode }}&hashtags={{ (community.hashtag | replace('#', '')) | urlencode }}"
+   target="_blank" rel="noopener" class="share-button" title="Xでシェア">
+  <svg class="icon" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+  <span>シェア</span>
+</a>
+{%- endmacro %}

--- a/src/templates/event_detail.html
+++ b/src/templates/event_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import share_button with context %}
 
 {% block title %}{{ event.title }} | {{ site_name }}{% endblock %}
 {% block og_title %}{{ event.title }}{% endblock %}
@@ -28,7 +29,14 @@
         </a>
         {% endif %}
         {% if event.hashtag %}
+        {% if site_url %}
+        <a href="https://twitter.com/intent/tweet?text={{ event.title | urlencode }}&url={{ (site_url + '/events/' + '%03d' | format(event.number)) | urlencode }}&hashtags={{ (event.hashtag | replace('#', '')) | urlencode }}"
+           target="_blank" rel="noopener" class="meta-item hashtag hashtag-share" title="Xでシェア">
+          {{ event.hashtag }}
+        </a>
+        {% else %}
         <span class="meta-item hashtag">{{ event.hashtag }}</span>
+        {% endif %}
         {% endif %}
       </div>
     </header>

--- a/src/templates/speaker_detail.html
+++ b/src/templates/speaker_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import share_button with context %}
 
 {% block title %}{{ speaker.name }} の発表一覧 | {{ site_name }}{% endblock %}
 {% block nav_speakers %}active{% endblock %}
@@ -53,7 +54,12 @@
   </header>
 
   <section class="speaker-talks-section">
-    <h2>発表一覧</h2>
+    <div class="section-header-row">
+      <h2>発表一覧</h2>
+      {% if site_url %}
+      {{ share_button(speaker.name + ' の発表一覧 | ' + site_name, '/speakers/' + speaker.id) }}
+      {% endif %}
+    </div>
     <div class="speaker-talks">
       {% for talk in speaker.talks %}
       <div class="speaker-talk-card">


### PR DESCRIPTION
## Summary
- イベント詳細ページと登壇者詳細ページにXシェア導線を追加
- 共通マクロ `_macros.html` を新規追加しシェアボタンを再利用可能に
- 本家 easy2-portal の [PR #2](https://github.com/unsolublesugar/easy2-portal/pull/2) と同じ内容を取り込み

Closes #4

## 変更内容

### イベント詳細ページ（`/events/NNN`）
メタ情報エリアのハッシュタグ自体をクリック可能なシェアリンクに変更。ホバー時に背景色が薄い青系に変化。

### 登壇者詳細ページ（`/speakers/{id}`）
「発表一覧」セクション見出しの右端にテキスト付きシェアボタンを配置。

### テンプレート利用時の配慮
- `SITE_URL` をサンプルページのGitHub Pages URLに設定
- `SITE_URL` が空の場合はシェアボタン／リンクを非表示にし、テンプレートとしての汎用性を維持

## Test plan
- [x] イベント詳細ページのハッシュタグをクリックしてXのシェア画面が開くことを確認
- [x] 登壇者詳細ページの「発表一覧」右端のボタンをクリックしてXのシェア画面が開くことを確認
- [x] シェアURLに絶対URLが含まれていることを確認
- [x] モバイル表示でレイアウトが崩れないことを確認