### PR TITLE
開催予定イベントで確定LT登壇者を表示できるようにする

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -36,15 +36,27 @@ def load_yaml(filepath: Path) -> dict:
 def load_all_events() -> list[dict]:
     """全イベントデータを読み込み、番号降順でソートして返す"""
     events = []
+    today = datetime.now().date()
     for yaml_file in sorted(EVENTS_DIR.glob("*.yaml"), reverse=True):
         event = load_yaml(yaml_file)
         if event:
-            # 発表数をカウント（TBD除外）
             talks = event.get("talks", [])
             event["talk_count"] = len([
                 t for t in talks
                 if t.get("speaker", {}).get("id") != "tbd"
             ])
+            event["tbd_count"] = len([
+                t for t in talks
+                if t.get("speaker", {}).get("id") == "tbd"
+            ])
+            event["is_upcoming"] = False
+            date_str = event.get("date", "")
+            if date_str:
+                try:
+                    event_date = datetime.strptime(str(date_str), "%Y-%m-%d").date()
+                    event["is_upcoming"] = event_date >= today
+                except ValueError:
+                    pass
             events.append(event)
     return events
 

--- a/src/templates/event_detail.html
+++ b/src/templates/event_detail.html
@@ -84,8 +84,8 @@
 
     <section class="talks-section">
       <h2>発表一覧</h2>
-      {% for talk in event.talks %}
-      {% if talk.speaker.id != 'tbd' %}
+      {% set confirmed_talks = event.talks | selectattr('speaker.id', 'ne', 'tbd') | list %}
+      {% for talk in confirmed_talks %}
       <div class="talk-card" id="talk-{{ loop.index }}">
         {% set has_speaker_page = talk.speaker.id != 'tbd' %}
         <div class="talk-card-header">
@@ -187,15 +187,19 @@
           {% endif %}
         </div>
       </div>
-      {% else %}
+      {% endfor %}
+      {% if event.tbd_count and event.tbd_count > 0 %}
       <div class="talk-card talk-card-tbd">
+        {% if confirmed_talks %}
+        <p class="tbd-message">発表者あと{{ event.tbd_count }}枠募集中です！参加をご検討ください。</p>
+        {% else %}
         <p class="tbd-message">発表者募集中です！参加をご検討ください。</p>
+        {% endif %}
         {% if event.connpass_url %}
         <a href="{{ event.connpass_url }}" target="_blank" rel="noopener" class="btn btn-outline">connpassで申し込む</a>
         {% endif %}
       </div>
       {% endif %}
-      {% endfor %}
     </section>
 
     <nav class="event-nav">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -43,7 +43,8 @@
 
     <div class="events-grid" id="eventsGrid">
       {% for event in events %}
-      {% set is_upcoming = event.talks and event.talks[0].speaker.id == 'tbd' %}
+      {% set is_upcoming = event.is_upcoming %}
+      {% set confirmed_talks = event.talks | selectattr('speaker.id', 'ne', 'tbd') | list if event.talks else [] %}
       <a href="{{ base_path }}/events/{{ '%03d' | format(event.number) }}" class="event-card{% if is_upcoming %} event-card-upcoming{% endif %}" data-year="{{ event.date[:4] if event.date else '' }}">
         <div class="event-card-header">
           <div class="event-card-header-left">
@@ -57,7 +58,26 @@
         <h3 class="event-card-title">{{ event.title }}</h3>
         {% if is_upcoming %}
         <div class="event-upcoming-body">
+          {% if confirmed_talks %}
+          <div class="event-card-talks">
+            {% for talk in confirmed_talks[:3] %}
+            <div class="talk-preview">
+              <span class="talk-preview-bullet"></span>
+              <span class="talk-preview-title">{{ talk.title }}</span>
+            </div>
+            {% endfor %}
+            {% if confirmed_talks | length > 3 %}
+            <span class="talk-more">+ {{ confirmed_talks | length - 3 }}件</span>
+            {% endif %}
+          </div>
+          {% endif %}
+          {% if event.tbd_count == 0 and confirmed_talks %}
+          <p class="event-upcoming-message">登壇者確定！ぜひご参加ください。</p>
+          {% elif confirmed_talks %}
+          <p class="event-upcoming-message">残り{{ event.tbd_count }}枠 登壇者募集中！</p>
+          {% else %}
           <p class="event-upcoming-message">参加者・登壇者募集中！</p>
+          {% endif %}
           {% if event.connpass_url %}
           <span class="event-upcoming-cta">connpassでチェック →</span>
           {% endif %}


### PR DESCRIPTION
## Summary
- 開催予定カード／イベント詳細ページで、確定したLT登壇者・発表タイトルを表示できるようにした
- TBD 枠の募集メッセージを残り枠数に応じて切り替え（全TBD／部分確定／全確定）

Closes #5

## 変更内容

### `src/build.py`
- `is_upcoming` をイベント日付ベースで判定（従来は `talks[0]` が TBD かで判定していた）
- `tbd_count` をイベントに付与

### `src/templates/index.html`
- 開催予定カードの表示ロジック刷新
  - 確定者なし: 「参加者・登壇者募集中！」
  - 部分確定: 確定LTタイトル一覧 + 「残り{N}枠 登壇者募集中！」
  - 全枠確定: 確定LTタイトル一覧 + 「登壇者確定！ぜひご参加ください。」

### `src/templates/event_detail.html`
- 確定LTのみを発表カードとしてループ表示
- 残TBD枠は1枚のカードに集約し、メッセージを切り替え
  - 全TBD: 「発表者募集中です！参加をご検討ください。」
  - 部分確定: 「発表者あと{N}枠募集中です！参加をご検討ください。」
  - 全確定: TBDカード非表示

## Test plan
- [x] ローカルビルド成功
- [x] サンプル `001.yaml` を一時的に未来日付＋TBD混在に書き換えて、全TBD・部分確定・全確定の3ケースでトップページ／詳細ページの表示を確認（検証後はサンプル復元）
- [x] 既存の過去イベント（is_upcoming=False）の表示が壊れていないことを確認
- [ ] GitHub Pages デプロイ後の本番表示確認