### PR TITLE
/live/ 形式 YouTube URL でのタイムスタンプジャンプ不具合修正

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -39,6 +39,8 @@ def load_all_events() -> list[dict]:
     for yaml_file in sorted(EVENTS_DIR.glob("*.yaml"), reverse=True):
         event = load_yaml(yaml_file)
         if event:
+            if event.get("youtube_url"):
+                event["youtube_url"] = normalize_youtube_url(event["youtube_url"])
             # 発表数をカウント（TBD除外）
             talks = event.get("talks", [])
             event["talk_count"] = len([
@@ -214,6 +216,21 @@ def extract_youtube_video_id(url: str) -> str:
     elif "/live/" in url:
         return url.split("/live/")[1].split("?")[0]
     return ""
+
+
+def normalize_youtube_url(url: str) -> str:
+    """YouTube URLを `watch?v=VIDEO_ID` 形式に正規化する。
+
+    テンプレートで `&t=Xs` を付与する都合上、URLは `?v=` を含む形式である必要がある。
+    `/live/` や `youtu.be/` 形式のままだと `&t=` が `?` の前に付き再生位置が無視されるため、
+    ここで `watch?v=` 形式に揃える。
+    """
+    if not url:
+        return ""
+    video_id = extract_youtube_video_id(url)
+    if not video_id:
+        return url
+    return f"https://www.youtube.com/watch?v={video_id}"
 
 
 def youtube_embed_url(url: str, timestamp: str = "") -> str:


### PR DESCRIPTION
## Summary
- `youtube_url` が `/live/VIDEO_ID` または `youtu.be/VIDEO_ID` 形式のとき、「動画を見る」リンクで指定再生位置にジャンプしない不具合を修正
- ビルド時に `watch?v=VIDEO_ID` 形式へ正規化することで、`&t=` パラメータが正しく機能するようにする

Closes #6

## 不具合の原因

`event_detail.html` で再生位置リンクを `{{ event.youtube_url }}&t=...s` として組み立てているため、`/live/` 形式 URL の場合、生成URLが `.../live/VIDEO_ID&t=1276s` となり不正な形式になる（`?` が無いので `&t=` ではない）。
YouTube は寛容に処理するものの再生位置パラメータが渡らず、動画の冒頭から再生されていた。

## 修正内容

### `src/build.py`
- `normalize_youtube_url()` を追加（既存の `extract_youtube_video_id()` を使って `watch?v=` 形式に変換）
- `load_all_events()` で各イベント読み込み時に `event["youtube_url"]` を正規化
- YAMLは書き換えず、ビルド側で吸収

## Test plan
- [x] ローカルビルド成功
- [x] サンプル `002.yaml` の `youtube_url` を一時的に `/live/` 形式に書き換え、`watch?v=...&t=...s` 形式のリンクが生成されることを確認（検証後はサンプル復元）
- [x] 出力HTML 全体に `youtube.com/live/` 形式のURLが残存していないことを確認
- [ ] GitHub Pages デプロイ後、本番でリンクから指定位置にジャンプすることを確認