### PR TITLE
SlideShare の自動 iframe 埋め込みを廃止

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -316,14 +316,8 @@ def generate_slide_embed_url(slide_url: str, sd_cache: dict[str, str]) -> str:
             return f"https://www.docswell.com/slide/{slug}/embed"
 
     # --- SlideShare ---
-    if "slideshare.net/" in slide_url and "/embed" not in slide_url:
-        # URL例: https://www.slideshare.net/USERNAME/SLUG
-        # 埋め込み: https://www.slideshare.net/slideshow/SLUG/embed
-        # ※ secret リンクはスキップ
-        if "/secret/" not in slide_url:
-            slug = slide_url.split("?")[0].split("#")[0].rstrip("/").split("/")[-1]
-            if slug:
-                return f"https://www.slideshare.net/slideshow/{slug}/embed"
+    # SlideShare は anti-bot challenge により iframe 埋め込みが不安定なため、
+    # 自動 embed は生成せず、外部リンクのみとする。
 
     # --- slides.com ---
     if "slides.com/" in slide_url and "/embed" not in slide_url:


### PR DESCRIPTION
## Summary
SlideShare の iframe 埋め込みが anti-bot challenge により機能しなくなっているため、自動 embed URL 生成を廃止する。
スライドへの導線は引き続き「スライドを見る」外部リンクとして残る。

Closes #7

## 事象

SlideShare 埋め込み iframe 内に「www.slideshare.net で接続が拒否されました」のエラー表示。

## 原因

SlideShare 側で全 URL（embed URLを含む）に対して JavaScript ベースの Client Challenge が返されるようになっており、iframe 内では Challenge を解決できず本来のコンテンツが表示されない。
URL 形式の問題ではなく SlideShare 側の仕様変更で、`build.py` 側で URL を作り変えても解消しない。

## 修正内容

### `src/build.py`
`generate_slide_embed_url()` 内 SlideShare 分岐を無効化。

```python
# --- SlideShare ---
# SlideShare は anti-bot challenge により iframe 埋め込みが不安定なため、
# 自動 embed は生成せず、外部リンクのみとする。
```

YAML は触らない。`slide_url` は引き続き「スライドを見る」リンクの遷移先として使われる。

## Test plan
- [x] ローカルビルド成功
- [x] `generate_slide_embed_url()` を直接呼び、SlideShare URL が空文字列を返すことを確認
- [x] Google Slides / Docswell / slides.com の埋め込みURLが従来どおり生成されることを確認
- [ ] GitHub Pages デプロイ後の本番表示確認