### PR TITLE
開催予定イベントのサンプルを追加

### DIFF
--- a/data/events/004.yaml
+++ b/data/events/004.yaml
@@ -1,0 +1,19 @@
+number: 4
+title: 'LTイベント #4（開催予定・全TBDサンプル）'
+date: '2026-05-27'
+connpass_url: https://connpass.com/
+youtube_url: ''
+hashtag: '#MyLT'
+talks:
+- title: （発表者募集中）
+  speaker:
+    name: TBD
+    id: tbd
+- title: （発表者募集中）
+  speaker:
+    name: TBD
+    id: tbd
+- title: （発表者募集中）
+  speaker:
+    name: TBD
+    id: tbd

--- a/data/events/005.yaml
+++ b/data/events/005.yaml
@@ -1,0 +1,23 @@
+number: 5
+title: 'LTイベント #5（開催予定・部分確定サンプル）'
+date: '2026-06-24'
+connpass_url: https://connpass.com/
+youtube_url: ''
+hashtag: '#MyLT'
+talks:
+- title: サンプルLT - 確定枠1
+  speaker:
+    name: Speaker A
+    id: speaker_a
+  tags:
+  - サンプル
+- title: サンプルLT - 確定枠2
+  speaker:
+    name: Speaker B
+    id: speaker_b
+  tags:
+  - サンプル
+- title: （発表者募集中）
+  speaker:
+    name: TBD
+    id: tbd


### PR DESCRIPTION
## Summary
PR #8 で導入した `is_upcoming` / `tbd_count` による開催予定カードの表示分岐を、サンプルページでもそのまま確認できるように、未来日付のサンプルイベントを2件追加する。

## 変更内容

### `data/events/004.yaml`（新規）
- 未来日付（2026-05-27）× 全TBD（3枠）
- トップページ: 「参加者・登壇者募集中！」+ 「開催予定」バッジ
- 詳細ページ: 「発表者募集中です！参加をご検討ください。」（TBDカード1枚集約）

### `data/events/005.yaml`（新規）
- 未来日付（2026-06-24）× 部分確定（Speaker A / Speaker B 確定 + TBD 1枠）
- トップページ: 確定LTタイトル一覧 + 「残り1枠 登壇者募集中！」+ 「開催予定」バッジ
- 詳細ページ: 確定LT 2件 + 「発表者あと1枠募集中です！参加をご検討ください。」

既存の 001/002（過去・全確定）と 003（過去・全TBD）はそのまま維持。

## Test plan
- [x] ローカルビルド成功
- [x] `output/index.html` に「開催予定」バッジが2件表示されることを確認
- [x] 004 の詳細ページで全TBD用メッセージが表示されることを確認
- [x] 005 の詳細ページで部分確定用メッセージ + 確定LTカード2枚が表示されることを確認